### PR TITLE
Generalize `zip` and `unzip`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,82 +4,116 @@
 
 ### Types
 
+
     data Tuple a b where
       Tuple :: a -> b -> Tuple a b
 
 
 ### Type Class Instances
 
+
     instance applicativeTuple :: (Monoid a) => Applicative (Tuple a)
+
 
     instance applyTuple :: (Semigroup a) => Apply (Tuple a)
 
+
     instance bindTuple :: (Semigroup a) => Bind (Tuple a)
+
 
     instance comonadTuple :: Comonad (Tuple a)
 
+
     instance eqTuple :: (Eq a, Eq b) => Eq (Tuple a b)
+
 
     instance extendTuple :: Extend (Tuple a)
 
+
     instance functorTuple :: Functor (Tuple a)
+
 
     instance lazyLazy1Tuple :: (Lazy1 l1, Lazy1 l2) => Lazy (Tuple (l1 a) (l2 b))
 
+
     instance lazyLazy2Tuple :: (Lazy2 l1, Lazy2 l2) => Lazy (Tuple (l1 a b) (l2 c d))
+
 
     instance lazyTuple :: (Lazy a, Lazy b) => Lazy (Tuple a b)
 
+
     instance monadTuple :: (Monoid a) => Monad (Tuple a)
+
 
     instance monoidTuple :: (Monoid a, Monoid b) => Monoid (Tuple a b)
 
+
     instance ordTuple :: (Ord a, Ord b) => Ord (Tuple a b)
+
 
     instance semigroupTuple :: (Semigroup a, Semigroup b) => Semigroup (Tuple a b)
 
+
     instance semigroupoidTuple :: Semigroupoid Tuple
+
 
     instance showTuple :: (Show a, Show b) => Show (Tuple a b)
 
 
 ### Values
 
+
     curry :: forall a b c. (Tuple a b -> c) -> a -> b -> c
+
 
     fst :: forall a b. Tuple a b -> a
 
+
     snd :: forall a b. Tuple a b -> b
+
 
     swap :: forall a b. Tuple a b -> Tuple b a
 
+
     uncurry :: forall a b c. (a -> b -> c) -> Tuple a b -> c
 
-    unzip :: forall a b. [Tuple a b] -> Tuple [a] [b]
 
-    zip :: forall a b. [a] -> [b] -> [Tuple a b]
+    unzip :: forall f a b. (Functor f) => f (Tuple a b) -> Tuple (f a) (f b)
+
+
+    zip :: forall f a b. (Apply f) => f a -> f b -> f (Tuple a b)
 
 
 ## Module Data.Tuple.Nested
 
 ### Values
 
+
     (/\) :: forall a b. a -> b -> Tuple a b
+
 
     con10 :: forall a b c d e f g h i j z. (a -> b -> c -> d -> e -> f -> g -> h -> i -> j -> z) -> Tuple a (Tuple b (Tuple c (Tuple d (Tuple e (Tuple f (Tuple g (Tuple h (Tuple i j)))))))) -> z
 
+
     con2 :: forall a b z. (a -> b -> z) -> Tuple a b -> z
+
 
     con3 :: forall a b c z. (a -> b -> c -> z) -> Tuple a (Tuple b c) -> z
 
+
     con4 :: forall a b c d z. (a -> b -> c -> d -> z) -> Tuple a (Tuple b (Tuple c d)) -> z
+
 
     con5 :: forall a b c d e z. (a -> b -> c -> d -> e -> z) -> Tuple a (Tuple b (Tuple c (Tuple d e))) -> z
 
+
     con6 :: forall a b c d e f z. (a -> b -> c -> d -> e -> f -> z) -> Tuple a (Tuple b (Tuple c (Tuple d (Tuple e f)))) -> z
+
 
     con7 :: forall a b c d e f g z. (a -> b -> c -> d -> e -> f -> g -> z) -> Tuple a (Tuple b (Tuple c (Tuple d (Tuple e (Tuple f g))))) -> z
 
+
     con8 :: forall a b c d e f g h z. (a -> b -> c -> d -> e -> f -> g -> h -> z) -> Tuple a (Tuple b (Tuple c (Tuple d (Tuple e (Tuple f (Tuple g h)))))) -> z
+
 
     con9 :: forall a b c d e f g h i z. (a -> b -> c -> d -> e -> f -> g -> h -> i -> z) -> Tuple a (Tuple b (Tuple c (Tuple d (Tuple e (Tuple f (Tuple g (Tuple h i))))))) -> z

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@
     unzip :: forall f a b. (Functor f) => f (Tuple a b) -> Tuple (f a) (f b)
 
 
-    zip :: forall f a b. (Apply f) => f a -> f b -> f (Tuple a b)
+    zip :: forall a b. [a] -> [b] -> [Tuple a b]
 
 
 ## Module Data.Tuple.Nested

--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,6 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-arrays": "~0.3.0",
     "purescript-monoid": "~0.1.4",
     "purescript-control": "~0.2.1"
   }

--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,7 @@
     "package.json"
   ],
   "dependencies": {
+    "purescript-arrays": "~0.3.0",
     "purescript-monoid": "~0.1.4",
     "purescript-control": "~0.2.1"
   }

--- a/src/Data/Tuple.purs
+++ b/src/Data/Tuple.purs
@@ -3,7 +3,6 @@ module Data.Tuple where
   import Control.Extend
   import Control.Lazy
 
-  import Data.Array
   import Data.Monoid
 
   data Tuple a b = Tuple a b
@@ -71,13 +70,11 @@ module Data.Tuple where
   uncurry :: forall a b c. (a -> b -> c) -> Tuple a b -> c
   uncurry f (Tuple a b) = f a b
 
-  zip :: forall a b. [a] -> [b] -> [Tuple a b]
-  zip = zipWith Tuple
+  zip :: forall f a b. (Apply f) => f a -> f b -> f (Tuple a b)
+  zip fa fb = Tuple <$> fa <*> fb
 
-  unzip :: forall a b. [Tuple a b] -> Tuple [a] [b]
-  unzip ((Tuple a b):ts) = case unzip ts of
-    Tuple as bs -> Tuple (a : as) (b : bs)
-  unzip [] = Tuple [] []
+  unzip :: forall f a b. (Functor f) => f (Tuple a b) -> Tuple (f a) (f b)
+  unzip f = Tuple (fst <$> f) (snd <$> f)
 
   swap :: forall a b. Tuple a b -> Tuple b a
   swap (Tuple a b) = Tuple b a

--- a/src/Data/Tuple.purs
+++ b/src/Data/Tuple.purs
@@ -3,6 +3,7 @@ module Data.Tuple where
   import Control.Extend
   import Control.Lazy
 
+  import Data.Array
   import Data.Monoid
 
   data Tuple a b = Tuple a b
@@ -70,8 +71,8 @@ module Data.Tuple where
   uncurry :: forall a b c. (a -> b -> c) -> Tuple a b -> c
   uncurry f (Tuple a b) = f a b
 
-  zip :: forall f a b. (Apply f) => f a -> f b -> f (Tuple a b)
-  zip fa fb = Tuple <$> fa <*> fb
+  zip :: forall a b. [a] -> [b] -> [Tuple a b]
+  zip = zipWith Tuple
 
   unzip :: forall f a b. (Functor f) => f (Tuple a b) -> Tuple (f a) (f b)
   unzip f = Tuple (fst <$> f) (snd <$> f)


### PR DESCRIPTION
This is a discussion PR.

We can make `zip` and `unzip` more general than they are by relying on `Apply` and `Functor` respectively. This removes the dependency on `purescript-arrays`. But it also changes the semantics of `zip` a bit if you're not careful. This would require us to have a `ZipList` type in order to get he semantics we're all used to with the `zip` function. `unzip` works the same way regardless as there's only one valid `Functor`.

This PR gives us the ability to `zip`/`unzip` say two `Maybe`s, two `Map k`s, or two `V err`s or anything with just an `Apply`

So, is it worth it to break the semantics for more generality and removal of a dependency?