### PR TITLE
Adds /\ type-level operator.

### DIFF
--- a/src/Data/Tuple/Nested.purs
+++ b/src/Data/Tuple/Nested.purs
@@ -30,6 +30,11 @@ import Data.Tuple (Tuple(..))
 -- | `a /\ b /\ c /\ d /\ unit` becomes `Tuple a (Tuple b (Tuple c (Tuple d unit)))`
 infixr 6 Tuple as /\
 
+-- | Shorthand for constructing n-tuple types as nested pairs.
+-- | `forall a b c d. a /\ b /\ c /\ d /\ Unit` becomes
+-- | `forall a b c d. Tuple a (Tuple b (Tuple c (Tuple d Unit)))`
+infixr 6 type Tuple as /\
+
 type Tuple1 a = T2 a Unit
 type Tuple2 a b = T3 a b Unit
 type Tuple3 a b c = T4 a b c Unit

--- a/src/Data/Tuple/Nested.purs
+++ b/src/Data/Tuple/Nested.purs
@@ -27,7 +27,7 @@ import Prelude
 import Data.Tuple (Tuple(..))
 
 -- | Shorthand for constructing n-tuples as nested pairs.
--- | `a /\ b /\ c /\ d /\ unit` becomes `Tuple a (Tuple b (Tuple c (Tuple d (Tuple unit))))`
+-- | `a /\ b /\ c /\ d /\ unit` becomes `Tuple a (Tuple b (Tuple c (Tuple d unit)))`
 infixr 6 Tuple as /\
 
 type Tuple1 a = T2 a Unit


### PR DESCRIPTION
This adds `/\` as a type operator alias, and corrects (I think...?) a comment on the value-level operator alias while I was at it.

With no tests in the repo, I've tested by swapping out some of the T2, T3 type aliases with `/\`s, and it worked out. I've left those uncommitted, but I'm happy to add them in or make other changes if you think they'd be useful.

(This should close #24.)