### PR TITLE
Make doc-comment for Apply instance refer to the correct class

### DIFF
--- a/src/Data/Tuple.purs
+++ b/src/Data/Tuple.purs
@@ -107,7 +107,7 @@ instance invariantTuple :: Invariant (Tuple a) where
 instance bifunctorTuple :: Bifunctor Tuple where
   bimap f g (Tuple x y) = Tuple (f x) (g y)
 
--- | The `Functor` instance allows functions to transform the contents of a
+-- | The `Apply` instance allows functions to transform the contents of a
 -- | `Tuple` with the `<*>` operator whenever there is a `Semigroup` instance
 -- | for the `fst` component, so:
 -- | ```purescript


### PR DESCRIPTION
The doc-comment for the Apply instance referred to 'Functor' when it
clearly should have been 'Apply'.
