### PR TITLE
Refactor functors and related packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ Notable changes to this project are documented in this file. The format is based
 
 Breaking changes:
 - Added support for PureScript 0.14 and dropped support for all previous versions (#37, #43)
+- `Data.Tuple.lookup` has been moved to `Data.Foldable.lookup` in the `purescript-foldable-traversable` package (#46)
 
 New features:
 - Added Generic instance for Tuple (#40)
+- This package no longer depends on the `purescript-bifunctors`, `purescript-distributive`, `purescript-foldable-traversable`, `purescript-maybe`, `purescript-newtype`, and `purescript-type-equality` packages. Relevant instances have been moved to those packages. (#46)
 
 Bugfixes:
 

--- a/bower.json
+++ b/bower.json
@@ -16,14 +16,8 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-bifunctors": "master",
     "purescript-control": "master",
-    "purescript-distributive": "master",
-    "purescript-foldable-traversable": "master",
     "purescript-invariant": "master",
-    "purescript-maybe": "master",
-    "purescript-newtype": "master",
-    "purescript-prelude": "master",
-    "purescript-type-equality": "master"
+    "purescript-prelude": "master"
   }
 }

--- a/src/Data/Tuple.purs
+++ b/src/Data/Tuple.purs
@@ -3,31 +3,14 @@ module Data.Tuple where
 
 import Prelude
 
-import Control.Biapplicative (class Biapplicative)
-import Control.Biapply (class Biapply)
 import Control.Comonad (class Comonad)
 import Control.Extend (class Extend)
 import Control.Lazy (class Lazy, defer)
-import Data.Bifoldable (class Bifoldable)
-import Data.Bifunctor (class Bifunctor)
-import Data.Bitraversable (class Bitraversable)
-import Data.Distributive (class Distributive, collectDefault)
 import Data.Eq (class Eq1)
-import Data.Foldable (class Foldable, foldMap)
-import Data.FoldableWithIndex (class FoldableWithIndex)
 import Data.Functor.Invariant (class Invariant, imapF)
-import Data.FunctorWithIndex (class FunctorWithIndex)
 import Data.Generic.Rep (class Generic)
 import Data.HeytingAlgebra (implies, ff, tt)
-import Data.Maybe (Maybe(..))
-import Data.Maybe.First (First(..))
-import Data.Newtype (unwrap)
 import Data.Ord (class Ord1)
-import Data.Semigroup.Foldable (class Foldable1)
-import Data.Semigroup.Traversable (class Traversable1)
-import Data.Traversable (class Traversable)
-import Data.TraversableWithIndex (class TraversableWithIndex)
-import Type.Equality (class TypeEquals, from)
 
 -- | A simple product type for wrapping a pair of component values.
 data Tuple a b = Tuple a b
@@ -99,16 +82,10 @@ instance booleanAlgebraTuple :: (BooleanAlgebra a, BooleanAlgebra b) => BooleanA
 -- | ````
 derive instance functorTuple :: Functor (Tuple a)
 
-instance functorWithIndexTuple :: FunctorWithIndex Unit (Tuple a) where
-  mapWithIndex f = map $ f unit
-
 derive instance genericTuple :: Generic (Tuple a b) _
 
 instance invariantTuple :: Invariant (Tuple a) where
   imap = imapF
-
-instance bifunctorTuple :: Bifunctor Tuple where
-  bimap f g (Tuple x y) = Tuple (f x) (g y)
 
 -- | The `Apply` instance allows functions to transform the contents of a
 -- | `Tuple` with the `<*>` operator whenever there is a `Semigroup` instance
@@ -119,14 +96,8 @@ instance bifunctorTuple :: Bifunctor Tuple where
 instance applyTuple :: (Semigroup a) => Apply (Tuple a) where
   apply (Tuple a1 f) (Tuple a2 x) = Tuple (a1 <> a2) (f x)
 
-instance biapplyTuple :: Biapply Tuple where
-  biapply (Tuple f g) (Tuple a b) = Tuple (f a) (g b)
-
 instance applicativeTuple :: (Monoid a) => Applicative (Tuple a) where
   pure = Tuple mempty
-
-instance biapplicativeTuple :: Biapplicative Tuple where
-  bipure = Tuple
 
 instance bindTuple :: (Semigroup a) => Bind (Tuple a) where
   bind (Tuple a1 b) f = case f b of
@@ -142,45 +113,6 @@ instance comonadTuple :: Comonad (Tuple a) where
 
 instance lazyTuple :: (Lazy a, Lazy b) => Lazy (Tuple a b) where
   defer f = Tuple (defer $ \_ -> fst (f unit)) (defer $ \_ -> snd (f unit))
-
-instance foldableTuple :: Foldable (Tuple a) where
-  foldr f z (Tuple _ x) = f x z
-  foldl f z (Tuple _ x) = f z x
-  foldMap f (Tuple _ x) = f x
-
-instance foldable1Tuple :: Foldable1 (Tuple a) where
-  foldMap1 f (Tuple _ x) = f x
-  foldr1 _ (Tuple _ x) = x
-  foldl1 _ (Tuple _ x) = x
-
-instance foldableWithIndexTuple :: FoldableWithIndex Unit (Tuple a) where
-  foldrWithIndex f z (Tuple _ x) = f unit x z
-  foldlWithIndex f z (Tuple _ x) = f unit z x
-  foldMapWithIndex f (Tuple _ x) = f unit x
-
-instance bifoldableTuple :: Bifoldable Tuple where
-  bifoldMap f g (Tuple a b) = f a <> g b
-  bifoldr f g z (Tuple a b) = f a (g b z)
-  bifoldl f g z (Tuple a b) = g (f z a) b
-
-instance traversableTuple :: Traversable (Tuple a) where
-  traverse f (Tuple x y) = Tuple x <$> f y
-  sequence (Tuple x y) = Tuple x <$> y
-
-instance traversable1Tuple :: Traversable1 (Tuple a) where
-  traverse1 f (Tuple x y) = Tuple x <$> f y
-  sequence1 (Tuple x y) = Tuple x <$> y
-
-instance traversableWithIndexTuple :: TraversableWithIndex Unit (Tuple a) where
-  traverseWithIndex f (Tuple x y) = Tuple x <$> f unit y
-
-instance bitraversableTuple :: Bitraversable Tuple where
-  bitraverse f g (Tuple a b) = Tuple <$> f a <*> g b
-  bisequence (Tuple a b) = Tuple <$> a <*> b
-
-instance distributiveTuple :: TypeEquals a Unit => Distributive (Tuple a) where
-  collect = collectDefault
-  distribute = Tuple (from unit) <<< map snd
 
 -- | Returns the first component of a tuple.
 fst :: forall a b. Tuple a b -> a
@@ -201,7 +133,3 @@ uncurry f (Tuple a b) = f a b
 -- | Exchange the first and second components of a tuple.
 swap :: forall a b. Tuple a b -> Tuple b a
 swap (Tuple a b) = Tuple b a
-
--- | Lookup a value in a data structure of `Tuple`s, generalizing association lists.
-lookup :: forall a b f. Foldable f => Eq a => a -> f (Tuple a b) -> Maybe b
-lookup a = unwrap <<< foldMap \(Tuple a' b) -> First (if a == a' then Just b else Nothing)


### PR DESCRIPTION
This is part of a set of commits that rearrange the dependencies between
multiple packages. The immediate motivation is to allow certain newtypes
to be reused between `profunctor` and `bifunctors`, but this particular
approach goes a little beyond that in two ways: first, it attempts to
move data types (`either`, `tuple`) toward the bottom of the dependency
stack; and second, it tries to ensure no package comes between
`functors` and the packages most closely related to it, in order to open
the possibility of merging those packages together (which may be
desirable if at some point in the future additional newtypes are added
which reveal new and exciting constraints on the module dependency
graph).

**Description of the change**

See discussion in purescript/purescript-profunctor#23.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
